### PR TITLE
Issue58: add aggregation export files

### DIFF
--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -322,7 +322,13 @@ If every file in your directory will use the same munger(s) -- e.g., if the juri
  * aux_data_dir (optional -- use it if your files have all have the same auxiliary data files, which might never happen in practice)
 
 ## Pull Data
-The Analyzer class uses parameters in the file `run_time.ini`, which should be in the directory from which you are running the program.
+The Analyzer class uses parameters in the file `run_time.ini`, which should be in the directory from which you are running the program. This class has a number of functions that allow you to aggregate the data for analysis purposes. For example, running the `.top_counts()` function exports files into your rollup directory which with counts summed up at a particular reporting unit level. This function expects 4 arguments: the election, the jurisdiction, the reporting unit level at which the aggregation will occur, and a boolean variable indicating whether you would like the data aggregated by vote count type. For example:
+```
+from election_data_analysis import Analyzer
+analyzer = Analyzer()
+analyzer.top_counts('2018 General', 'North Carolina', 'county', True)
+```
+This code will produce all North Carolina data from the 2018 general election, grouped by contest, county, and vote type (total, early, absentee, etc).
 
 ## Miscellaneous helpful hints
 Beware of:

--- a/src/election_data_analysis/__init__.py
+++ b/src/election_data_analysis/__init__.py
@@ -223,9 +223,7 @@ class DataLoader:
             # move results file and its parameter file to a subfolder of the archive directory
             #  named for the db
             db_param = ui.get_runtime_parameters(
-                required_keys=["dbname"],
-                param_file="run_time.ini",
-                header="postgresql"
+                required_keys=["dbname"], param_file="run_time.ini", header="postgresql"
             )[0]
             self.tracker[f]["status"] = "loaded"
             new_dir = os.path.join(self.d["archive_dir"], db_param["dbname"])
@@ -362,7 +360,7 @@ class JurisdictionPrepper:
             d, parameter_err = ui.get_runtime_parameters(
                 required_keys=prep_pars,
                 param_file=param_file,
-                header="election_data_analysis"
+                header="election_data_analysis",
             )
         except FileNotFoundError as e:
             print(
@@ -1109,11 +1107,8 @@ class Analyzer:
         )
         return agg_results
 
-    def top_counts(self, 
-        election: str, 
-        rollup_unit: str, 
-        sub_unit: str,
-        by_vote_type: bool
+    def top_counts(
+        self, election: str, rollup_unit: str, sub_unit: str, by_vote_type: bool
     ) -> str:
         d, error = ui.get_runtime_parameters(
             required_keys=["rollup_directory"],
@@ -1126,12 +1121,17 @@ class Analyzer:
             print("Data not created.")
             return
         else:
-            rollup_unit_id = db.name_to_id(self.session, 'ReportingUnit', rollup_unit)
-            sub_unit_id = db.name_to_id(self.session, 'ReportingUnitType', sub_unit)
+            rollup_unit_id = db.name_to_id(self.session, "ReportingUnit", rollup_unit)
+            sub_unit_id = db.name_to_id(self.session, "ReportingUnitType", sub_unit)
             election_id = db.name_to_id(self.session, "Election", election)
-            err = a.create_rollup(self.session, d['rollup_directory'], top_ru_id=rollup_unit_id,
-                sub_rutype_id=sub_unit_id, 
-                election_id=election_id, by_vote_type=by_vote_type)
+            err = a.create_rollup(
+                self.session,
+                d["rollup_directory"],
+                top_ru_id=rollup_unit_id,
+                sub_rutype_id=sub_unit_id,
+                election_id=election_id,
+                by_vote_type=by_vote_type,
+            )
             return err
 
 

--- a/src/election_data_analysis/__init__.py
+++ b/src/election_data_analysis/__init__.py
@@ -1109,6 +1109,31 @@ class Analyzer:
         )
         return agg_results
 
+    def top_counts(self, 
+        election: str, 
+        rollup_unit: str, 
+        sub_unit: str,
+        by_vote_type: bool
+    ) -> str:
+        d, error = ui.get_runtime_parameters(
+            required_keys=["rollup_directory"],
+            param_file="run_time.ini",
+            header="election_data_analysis",
+        )
+        if error:
+            print("Parameter file missing requirements.")
+            print(error)
+            print("Data not created.")
+            return
+        else:
+            rollup_unit_id = db.name_to_id(self.session, 'ReportingUnit', rollup_unit)
+            sub_unit_id = db.name_to_id(self.session, 'ReportingUnitType', sub_unit)
+            election_id = db.name_to_id(self.session, "Election", election)
+            err = a.create_rollup(self.session, d['rollup_directory'], top_ru_id=rollup_unit_id,
+                sub_rutype_id=sub_unit_id, 
+                election_id=election_id, by_vote_type=by_vote_type)
+            return err
+
 
 def get_filename(path: str) -> str:
     head, tail = ntpath.split(path)

--- a/src/election_data_analysis/analyze/__init__.py
+++ b/src/election_data_analysis/analyze/__init__.py
@@ -43,9 +43,9 @@ def create_rollup(
     top_ru_id: int,
     sub_rutype_id: int,
     election_id: int,
-    datafile_list: list=None,
-    by: str="Id",
-    by_vote_type: bool=False
+    datafile_list: list = None,
+    by: str = "Id",
+    by_vote_type: bool = False,
 ) -> str:
     """<target_dir> is the directory where the resulting rollup will be stored.
     <election_id> identifies the election; <datafile_id_list> the datafile whose results will be rolled up.
@@ -117,7 +117,7 @@ def create_rollup(
             datafile_list,
             by=by,
             exclude_total=exclude_total,
-            by_vote_type=by_vote_type
+            by_vote_type=by_vote_type,
         )
         if not err_str:
             # create record for inventory.txt

--- a/src/election_data_analysis/analyze/__init__.py
+++ b/src/election_data_analysis/analyze/__init__.py
@@ -38,13 +38,14 @@ def child_rus_by_id(session, parents, ru_type=None):
 
 
 def create_rollup(
-    cursor,
+    session,
     target_dir: str,
     top_ru_id: int,
     sub_rutype_id: int,
     election_id: int,
-    datafile_list=None,
-    by="Id",
+    datafile_list: list=None,
+    by: str="Id",
+    by_vote_type: bool=False
 ) -> str:
     """<target_dir> is the directory where the resulting rollup will be stored.
     <election_id> identifies the election; <datafile_id_list> the datafile whose results will be rolled up.
@@ -56,8 +57,10 @@ def create_rollup(
     If no <datafile_list> is given, return all results for the given election.
     """
 
+    connection = session.bind.raw_connection()
+    cursor = connection.cursor()
     if not datafile_list:
-        datafile_list, e = db.data_file_list(cursor, [election_id], by="Id")
+        datafile_list, e = db.data_file_list(cursor, election_id, by="Id")
         if e:
             return e
         by = "Id"
@@ -106,22 +109,21 @@ def create_rollup(
                 f"There is already a file called {rollup_file}. Pick another name.\n"
             )
 
-        err = db.export_rollup_to_csv(
+        df, err_str = db.export_rollup_from_db(
             cursor,
             top_ru,
             sub_rutype,
             contest_type,
             datafile_list,
-            os.path.join(leaf_dir, rollup_file),
             by=by,
             exclude_total=exclude_total,
+            by_vote_type=by_vote_type
         )
-        if err:
-            err_str = err
-        else:
+        if not err_str:
             # create record for inventory.txt
             inv_df = inv_df.append(inventory, ignore_index=True).fillna("")
             err_str = None
+            df.to_csv(os.path.join(leaf_dir, rollup_file), index=False, sep="\t")
 
     # export to inventory file
     inv_df.to_csv(inventory_file, index=False, sep="\t")

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -168,9 +168,7 @@ def establish_connection(paramfile="run_time.ini", dbname=None):
     error message"""
     try:
         params = ui.get_runtime_parameters(
-            required_keys=db_pars,
-            param_file=paramfile,
-            header="postgresql"
+            required_keys=db_pars, param_file=paramfile, header="postgresql"
         )[0]
     except MissingSectionHeaderError as e:
         return {"message": "database.ini file not found suggested location."}
@@ -198,9 +196,7 @@ def create_new_db(project_root, param_file="run_time.ini"):
     # get connection to default postgres DB to create new one
     try:
         params = ui.get_runtime_parameters(
-            required_keys=db_pars,
-            param_file=param_file,
-            header="postgresql"
+            required_keys=db_pars, param_file=param_file, header="postgresql"
         )[0]
         db_name = params["dbname"]
         params["dbname"] = "postgres"
@@ -250,9 +246,7 @@ def sql_alchemy_connect(
 ) -> sqlalchemy.engine:
     """Returns an engine and a metadata object"""
     params = ui.get_runtime_parameters(
-        required_keys=db_pars,
-        param_file=paramfile,
-        header="postgresql"
+        required_keys=db_pars, param_file=paramfile, header="postgresql"
     )[0]
     if dbname != "postgres":
         params["dbname"] = dbname
@@ -715,8 +709,8 @@ def data_file_list(cursor, election_id, by="Id"):
         df_list = [x for (x,) in cursor.fetchall()]
         err_str = None
     except Exception as exc:
-       err_str = f"Database error pulling list of datafiles with election id in {election_id}: {exc}"
-       df_list = None
+        err_str = f"Database error pulling list of datafiles with election id in {election_id}: {exc}"
+        df_list = None
     return df_list, err_str
 
 
@@ -1272,7 +1266,7 @@ def export_rollup_from_db(
     datafile_list: iter,
     by: str = "Id",
     exclude_total: bool = False,
-    by_vote_type: bool = False
+    by_vote_type: bool = False,
 ):
     if by_vote_type:
         restrict = """ AND CIT."Txt" = 'total' """
@@ -1280,7 +1274,7 @@ def export_rollup_from_db(
         restrict = """ AND CIT."Txt" != 'total' """
     else:
         restrict = ""
-    
+
     columns = [
         "contest_type",
         "contest",
@@ -1288,10 +1282,11 @@ def export_rollup_from_db(
         "selection",
         "reporting_unit",
         "count_item_type",
-        "count"
+        "count",
     ]
     if contest_type == "Candidate":
-        q = sql.SQL("""
+        q = sql.SQL(
+            """
         SELECT 'Candidate' contest_type,
             C."Name" "Contest",
             EDRUT."Txt" contest_district_type,
@@ -1339,7 +1334,8 @@ def export_rollup_from_db(
         ).format(by=sql.Identifier(by), restrict=sql.SQL(restrict))
 
     elif contest_type == "BallotMeasure":
-        q = sql.SQL("""
+        q = sql.SQL(
+            """
         SELECT 'Candidate' contest_type,
             C."Name" "Contest",
             EDRUT."Txt" contest_district_type,

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -1268,7 +1268,7 @@ def export_rollup_from_db(
     exclude_total: bool = False,
     by_vote_type: bool = False,
 ):
-    if by_vote_type:
+    if not by_vote_type:
         restrict = """ AND CIT."Txt" = 'total' """
     elif exclude_total:
         restrict = """ AND CIT."Txt" != 'total' """

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -706,17 +706,17 @@ def vote_type_list(cursor, datafile_list: list, by: str = "Id") -> (list, str):
     return vt_list, err_str
 
 
-def data_file_list(cursor, election_id_list, by="Id"):
+def data_file_list(cursor, election_id, by="Id"):
     q = sql.SQL(
-        """SELECT distinct d.{by} FROM _datafile d WHERE d."Election_Id" in %s"""
+        """SELECT distinct d.{by} FROM _datafile d WHERE d."Election_Id" = %s"""
     ).format(by=sql.Identifier(by))
     try:
-        cursor.execute(q, [tuple(election_id_list)])
+        cursor.execute(q, (election_id,))
         df_list = [x for (x,) in cursor.fetchall()]
         err_str = None
     except Exception as exc:
-        err_str = f"Database error pulling list of datafiles with election id in {election_id_list}: {exc}"
-        df_list = None
+       err_str = f"Database error pulling list of datafiles with election id in {election_id}: {exc}"
+       df_list = None
     return df_list, err_str
 
 
@@ -1262,3 +1262,137 @@ def get_candidate_votecounts(session, election_id, top_ru_id, subdivision_type_i
     result_df = pd.DataFrame(result)
     result_df.columns = result.keys()
     return result_df
+
+
+def export_rollup_from_db(
+    cursor,
+    top_ru: str,
+    sub_unit_type: str,
+    contest_type: str,
+    datafile_list: iter,
+    by: str = "Id",
+    exclude_total: bool = False,
+    by_vote_type: bool = False
+):
+    if by_vote_type:
+        restrict = """ AND CIT."Txt" = 'total' """
+    elif exclude_total:
+        restrict = """ AND CIT."Txt" != 'total' """
+    else:
+        restrict = ""
+    
+    columns = [
+        "contest_type",
+        "contest",
+        "contest_district_type",
+        "selection",
+        "reporting_unit",
+        "count_item_type",
+        "count"
+    ]
+    if contest_type == "Candidate":
+        q = sql.SQL("""
+        SELECT 'Candidate' contest_type,
+            C."Name" "Contest",
+            EDRUT."Txt" contest_district_type,
+            Cand."BallotName" "Selection",
+            IntermediateRU."Name" "ReportingUnit",
+            CIT."Txt" "CountItemType",
+            sum(vc."Count") "Count"
+        FROM "VoteCount" vc
+        LEFT JOIN _datafile d on vc."_datafile_Id" = d."Id"
+        LEFT JOIN "Contest" C on vc."Contest_Id" = C."Id"
+        LEFT JOIN "CandidateSelection" CS on CS."Id" = vc."Selection_Id"
+        LEFT JOIN "Candidate" Cand on CS."Candidate_Id" = Cand."Id"
+        -- sum over all children
+        LEFT JOIN "ReportingUnit" ChildRU on vc."ReportingUnit_Id" = ChildRU."Id"
+        LEFT JOIN "ComposingReportingUnitJoin" CRUJ_sum on ChildRU."Id" = CRUJ_sum."ChildReportingUnit_Id"
+        -- roll up to the intermediate RUs
+        LEFT JOIN "ReportingUnit" IntermediateRU on CRUJ_sum."ParentReportingUnit_Id" =IntermediateRU."Id"
+        LEFT JOIN "ReportingUnitType" IntermediateRUT on IntermediateRU."ReportingUnitType_Id" = IntermediateRUT."Id"
+        -- intermediate RUs must nest in top RU
+        LEFT JOIN "ComposingReportingUnitJoin" CRUJ_top on IntermediateRU."Id" = CRUJ_top."ChildReportingUnit_Id"
+        LEFT JOIN "ReportingUnit" TopRU on CRUJ_top."ParentReportingUnit_Id" = TopRU."Id"
+        LEFT JOIN "CountItemType" CIT on vc."CountItemType_Id" = CIT."Id"
+        LEFT JOIN "CandidateContest" on C."Id" = "CandidateContest"."Id"
+        LEFT JOIN "Office" O on "CandidateContest"."Office_Id" = O."Id"
+        LEFT JOIN "ReportingUnit" ED on O."ElectionDistrict_Id" = ED."Id"
+        LEFT JOIN "ReportingUnitType" EDRUT on ED."ReportingUnitType_Id" = EDRUT."Id"
+        WHERE C.contest_type = 'Candidate'
+            AND TopRU."Name" = %s  -- top RU
+            AND IntermediateRUT."Txt" = %s  -- intermediate_reporting_unit_type
+            AND d.{by} in %s  -- tuple of datafile short_names
+            {restrict}
+        GROUP BY
+               C."Name",
+               EDRUT."Txt",
+               Cand."BallotName",
+              IntermediateRU."Name",
+               CIT."Txt"
+        ORDER BY
+               C."Name",
+               EDRUT."Txt",
+               Cand."BallotName",
+              IntermediateRU."Name",
+               CIT."Txt";
+        """
+        ).format(by=sql.Identifier(by), restrict=sql.SQL(restrict))
+
+    elif contest_type == "BallotMeasure":
+        q = sql.SQL("""
+        SELECT 'Candidate' contest_type,
+            C."Name" "Contest",
+            EDRUT."Txt" contest_district_type,
+            BMS."Name" "Selection",
+            IntermediateRU."Name" "ReportingUnit",
+            CIT."Txt" "CountItemType",
+            sum(vc."Count") "Count"
+        FROM "VoteCount" vc
+        LEFT JOIN _datafile d on vc."_datafile_Id" = d."Id"
+        LEFT JOIN "Contest" C on vc."Contest_Id" = C."Id"
+        LEFT JOIN "BallotMeasureContest" BMC on vc."Contest_Id" = BMC."Id"
+        LEFT JOIN "BallotMeasureSelection" BMS on BMS."Id" = vc."Selection_Id"
+        -- sum over all children
+        LEFT JOIN "ReportingUnit" ChildRU on vc."ReportingUnit_Id" = ChildRU."Id"
+        LEFT JOIN "ComposingReportingUnitJoin" CRUJ_sum on ChildRU."Id" = CRUJ_sum."ChildReportingUnit_Id"
+        -- roll up to the intermediate RUs
+        LEFT JOIN "ReportingUnit" IntermediateRU on CRUJ_sum."ParentReportingUnit_Id" =IntermediateRU."Id"
+        LEFT JOIN "ReportingUnitType" IntermediateRUT on IntermediateRU."ReportingUnitType_Id" = IntermediateRUT."Id"
+        -- intermediate RUs must nest in top RU
+        LEFT JOIN "ComposingReportingUnitJoin" CRUJ_top on IntermediateRU."Id" = CRUJ_top."ChildReportingUnit_Id"
+        LEFT JOIN "ReportingUnit" TopRU on CRUJ_top."ParentReportingUnit_Id" = TopRU."Id"
+        LEFT JOIN "CountItemType" CIT on vc."CountItemType_Id" = CIT."Id"
+        LEFT JOIN "ReportingUnit" ED on BMC."ElectionDistrict_Id" = ED."Id"
+        LEFT JOIN "ReportingUnitType" EDRUT on ED."ReportingUnitType_Id" = EDRUT."Id"
+        WHERE C.contest_type = 'BallotMeasure'
+            AND TopRU."Name" = %s  -- top RU
+            AND IntermediateRUT."Txt" = %s  -- intermediate_reporting_unit_type
+            AND d.{by} in %s  -- tuple of datafile short_names
+            {restrict}
+        GROUP BY
+               C."Name",
+               EDRUT."Txt",
+               BMS."Name",
+              IntermediateRU."Name",
+               CIT."Txt"
+        ORDER BY
+               C."Name",
+               EDRUT."Txt",
+               BMS."Name",
+              IntermediateRU."Name",
+               CIT."Txt";
+        """
+        ).format(by=sql.Identifier(by), restrict=sql.SQL(restrict))
+    else:
+        err_str = f"Unrecognized contest_type: {contest_type}. No results exported"
+        return err_str
+    try:
+        cursor.execute(q, [top_ru, sub_unit_type, tuple(datafile_list)])
+        results = cursor.fetchall()
+        results_df = pd.DataFrame(results)
+        results_df.columns = columns
+        err_str = None
+    except Exception as exc:
+        results_df = pd.DataFrame()
+        err_str = f"No results exported due to database error: {exc}"
+    return results_df, err_str

--- a/src/election_data_analysis/juris_and_munger/__init__.py
+++ b/src/election_data_analysis/juris_and_munger/__init__.py
@@ -237,7 +237,9 @@ class Munger:
                     int(x) for x in p_catch_digits.findall(r["raw_identifier_formula"])
                 ]
                 bad_integer_list = [
-                    x for x in integer_list if (x > self.options["header_row_count"] - 1 or x < 0)
+                    x
+                    for x in integer_list
+                    if (x > self.options["header_row_count"] - 1 or x < 0)
                 ]
                 if bad_integer_list:
                     bad_column_formula.add(r["raw_identifier_formula"])
@@ -331,7 +333,7 @@ def read_munger_info_from_files(dir_path):
         header="format",
         optional_keys=optional_keys,
     )
-    options = recast_options(options,munger_pars_opt)
+    options = recast_options(options, munger_pars_opt)
 
     file_type = options["file_type"]
     if "encoding" in options.keys():
@@ -347,12 +349,7 @@ def read_munger_info_from_files(dir_path):
 
     # TODO have options hold all optional parameters (and maybe even all parameters)
     #  and remove explicit attributes entirely?
-    return [cdf_elements,
-            file_type,
-            encoding,
-            thousands_separator,
-            aux_meta,
-            options]
+    return [cdf_elements, file_type, encoding, thousands_separator, aux_meta, options]
 
 
 # TODO combine ensure_jurisdiction_dir with ensure_juris_files
@@ -665,7 +662,11 @@ def check_munger_file_contents(munger_name, project_root):
 
     # check all parameters for concatenated blocks (e.g., Georgia ExpressVote output)
     elif format_d["file_type"] in ["concatenated-blocks"]:
-        for key in ["count_of_top_lines_to_skip", "last_header_column_count", "column_width"]:
+        for key in [
+            "count_of_top_lines_to_skip",
+            "last_header_column_count",
+            "column_width",
+        ]:
             try:
                 int(format_d[key])
             except ValueError or TypeError:

--- a/src/election_data_analysis/special_formats/__init__.py
+++ b/src/election_data_analysis/special_formats/__init__.py
@@ -22,10 +22,10 @@ def strip_empties(li: list) -> list:
 def remove_by_index(main_list: list, idx_list: list):
     """creates new list by removing from <new_list> indices indicated in <idx_list>.
     Indices in <idx_list> can be negative or positive. Positive indices are
-    removed first. """
+    removed first."""
     # TODO error checking for overlapping neg & pos indices
     new_list = main_list.copy()
-    not_neg = [idx for idx in idx_list if idx >=0]
+    not_neg = [idx for idx in idx_list if idx >= 0]
     not_neg.sort()
     not_neg.reverse()
     for idx in not_neg:
@@ -85,14 +85,16 @@ def read_concatenated_blocks(
             field_list = extract_items(header_line, w)
 
             # remove first column header and headers of any columns to be skipped
-            last_header = remove_by_index(field_list,[0] + skip_cols)
+            last_header = remove_by_index(field_list, [0] + skip_cols)
 
             # check that the size of the side-to-side repeated block is consistent
             if len(last_header) % v_t_cc != 0:
-                e = f"Count of last header (per munger) ({v_t_cc}) " \
-                    f"does not evenly divide the number of count columns in the results file " \
+                e = (
+                    f"Count of last header (per munger) ({v_t_cc}) "
+                    f"does not evenly divide the number of count columns in the results file "
                     f"({len(last_header)})"
-                ui.add_error(err,"munge_error",e)
+                )
+                ui.add_error(err, "munge_error", e)
                 return pd.DataFrame(), err
 
             header_1_list = extract_items(header_1, w * v_t_cc)
@@ -149,7 +151,7 @@ def read_concatenated_blocks(
         raw_results = pd.concat(list(df.values()))
     except ValueError as e:
         err = ui.add_error(
-            err,"datafile_error",f"Error concatenating data from blocks: {e}"
+            err, "datafile_error", f"Error concatenating data from blocks: {e}"
         )
         return pd.DataFrame, err
 

--- a/src/election_data_analysis/user_interface/__init__.py
+++ b/src/election_data_analysis/user_interface/__init__.py
@@ -440,7 +440,7 @@ def read_combine_results(
 ):
     if mu.options["file_type"] in ["concatenated-blocks"]:
         working, err = sf.read_concatenated_blocks(results_file, mu, err)
-        if working.empty or [x for x in err.keys() if 'error' in x]:
+        if working.empty or [x for x in err.keys() if "error" in x]:
             return working, err
         # set options that will be needed for going forward
         mu.options["count_columns"] = [working.columns.to_list().index("count")]
@@ -615,7 +615,9 @@ def get_runtime_parameters(
     try:
         h = parser[header]
     except KeyError as ke:
-        missing_required_params["header"] = f"Header not found in file {param_file}: {ke}"
+        missing_required_params[
+            "header"
+        ] = f"Header not found in file {param_file}: {ke}"
         return dict(), missing_required_params
 
     for k in required_keys:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,5 @@
+def func(x):
+    return x + 1
+
+def test_answer():
+    assert func(3) == 5

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,0 @@
-def func(x):
-    return x + 1
-
-def test_answer():
-    assert func(3) == 5


### PR DESCRIPTION
Adds back in the ability to export datafiles rolled up by contest, subdivision type (a child reporting unit type), and optionally split out by vote type.