### PR TITLE
Issue87 ini cleanup

### DIFF
--- a/src/election_data_analysis/user_interface/__init__.py
+++ b/src/election_data_analysis/user_interface/__init__.py
@@ -26,6 +26,7 @@ recognized_encodings = {
     "euc-jp",
     "ibm1026",
     "ascii",
+    "ASCII",
     "IBM437",
     "EBCDIC-CP-BE",
     "csshiftjis",
@@ -651,8 +652,8 @@ def consolidate_errors(list_of_err: list) -> Optional[Dict[Any, dict]]:
         name_keys = set().union(*[y.keys() for y in err_list])
         for nk in name_keys:
             msg_list_of_lists = [y[nk] for y in err_list if nk in y.keys()]
-            # assign list of all messages
-            d[et][nk] = [y for x in msg_list_of_lists for y in x]
+            # assign list of all messages (avoiding duplicates)
+            d[et][nk] = list({y for x in msg_list_of_lists for y in x})
     return d
 
 

--- a/src/mungers/mi_gen_by_county/cdf_elements.txt
+++ b/src/mungers/mi_gen_by_county/cdf_elements.txt
@@ -1,0 +1,8 @@
+name	raw_identifier_formula	source
+ReportingUnit	<CountyName>	row
+Party	<PartyName>	row
+CandidateContest	<OfficeDescription>	row
+Candidate	<CandidateFirstName> <CandidateMiddleName> <CandidateLastName>	row
+BallotMeasureContest	<OfficeDescription>	row
+BallotMeasureSelection	<CandidateLastName>	row
+CountItemType	total	row

--- a/src/mungers/mi_gen_by_county/format.config
+++ b/src/mungers/mi_gen_by_county/format.config
@@ -1,0 +1,6 @@
+[format]
+header_row_count=1
+field_name_row=0
+count_columns=14
+file_type=txt
+encoding=ASCII

--- a/src/mungers/mi_pri_by_county/cdf_elements.txt
+++ b/src/mungers/mi_pri_by_county/cdf_elements.txt
@@ -1,0 +1,8 @@
+name	raw_identifier_formula	source
+ReportingUnit	<CountyName>	row
+Party	<PartyName>	row
+CandidateContest	<OfficeDescription> (<PartyName>)	row
+Candidate	<CandidateFirstName> <CandidateMiddleName> <CandidateLastName>	row
+BallotMeasureContest	<OfficeDescription>	row
+BallotMeasureSelection	<CandidateLastName>	row
+CountItemType	total	row

--- a/src/mungers/mi_pri_by_county/format.config
+++ b/src/mungers/mi_pri_by_county/format.config
@@ -1,0 +1,6 @@
+[format]
+header_row_count=1
+field_name_row=0
+count_columns=15
+file_type=txt
+encoding=ASCII

--- a/src/parameter_file_templates/results.ini.template
+++ b/src/parameter_file_templates/results.ini.template
@@ -1,6 +1,6 @@
 [election_data_analysis]
 results_file=<just the name, not the path. File should be in the same directory as this parameter file>
-jurisdiction_path=<path/to/folder/containing/jurisdiction/definition/files>
+jurisdiction_directory=<just the name, not the path>
 munger_name=<comma-separated list of all mungers to be applied to the file.>
 top_reporting_unit=<internal db name from ReportingUnit table>
 election=<internal db name from Election table>


### PR DESCRIPTION
Closes #87 

- Allows a results.ini file to have only the name of the jurisdiction directory (`jurisdiction_directory`) rather than the entire path (with backward compatibility if instead the .ini file has the whole path (`jurisdiction_path`)
- Fixes a bug that repeated identical warning and error messages.
- Munges Michigan 2020 primary