### PR TITLE
Issue110, Issue35: fix anomaly score data export

### DIFF
--- a/src/election_data_analysis/__init__.py
+++ b/src/election_data_analysis/__init__.py
@@ -1282,14 +1282,14 @@ class Analyzer:
         # for now, bar charts can only handle jurisdictions where county is one level
         # down from the jurisdiction
         most_granular_id = db.name_to_id(self.session, "ReportingUnitType", "county")
-        hierarchy = db.get_jurisdiction_hierarchy(
-            self.session, jurisdiction_id, most_granular_id
+        subdivision_type_id = db.get_jurisdiction_hierarchy(
+            self.session, jurisdiction_id
         )
         # bar chart always at one level below top reporting unit
         agg_results = a.create_bar(
             self.session,
             jurisdiction_id,
-            hierarchy[1],
+            subdivision_type_id,
             contest_type,
             contest,
             election_id,

--- a/src/election_data_analysis/__init__.py
+++ b/src/election_data_analysis/__init__.py
@@ -1312,7 +1312,12 @@ class Analyzer:
         selection_type = input_str[len(count_item_type) + 1 :]
         return count_item_type, selection_type
 
-    def export_outlier_data(self, jurisdiction: str, contest: str = None):
+    def export_outlier_data(
+        self,
+        election: str,
+        jurisdiction: str,
+        contest: str=None,
+    ) -> list:
         """contest_type is one of state, congressional, state-senate, state-house"""
         d, error = ui.get_runtime_parameters(
             required_keys=["rollup_directory"],
@@ -1324,22 +1329,19 @@ class Analyzer:
             print(error)
             print("Data not created.")
             return
+        election_id = db.name_to_id(self.session, "Election", election)
         jurisdiction_id = db.name_to_id(self.session, "ReportingUnit", jurisdiction)
-        most_granular_id = db.name_to_id(
-            self.session, "ReportingUnitType", d["sub_reporting_unit_type"]
+        subdivision_type_id = db.get_jurisdiction_hierarchy(
+            self.session, jurisdiction_id
         )
-        hierarchy = db.get_jurisdiction_hierarchy(
-            self.session, jurisdiction_id, most_granular_id
-        )
-        results_info = db.get_datafile_info(self.session, self.d["results_file_short"])
         # bar chart always at one level below top reporting unit
         agg_results = a.create_bar(
             self.session,
             jurisdiction_id,
-            hierarchy[1],
+            subdivision_type_id,
             None,
             contest,
-            results_info[1],
+            election_id,
             True,
         )
         return agg_results

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -1227,32 +1227,35 @@ def get_relevant_contests(session, filters):
     return result_df
 
 
-# TODO: fix SQL when the hierarchy work is done 
-def get_jurisdiction_hierarchy(session, jurisdiction_id, subdivision_type_id):
-    q = session.execute(
-        f"""
-        SELECT  regexp_split_to_array("Name", ';') unit_array
-        FROM    "ComposingReportingUnitJoin" j
-                JOIN "ReportingUnit" ru ON j."ChildReportingUnit_Id" = ru."Id"
-        WHERE   "ParentReportingUnit_Id" = {jurisdiction_id}
-                AND "ReportingUnitType_Id" = {subdivision_type_id} 
+def get_jurisdiction_hierarchy(session, jurisdiction_id):
+    """get type of reporting unit one level down from jurisdiction.
+    Omit particular types that are contest types, not true reporting unit types"""
+    q = sql.SQL("""
+        SELECT  rut."Id"
+        FROM    "ComposingReportingUnitJoin" cruj
+                JOIN "ReportingUnit" ru on cruj."ChildReportingUnit_Id" = ru."Id"
+                JOIN "ReportingUnitType" rut on ru."ReportingUnitType_Id" = rut."Id"
+        WHERE   rut."Txt" not in (
+                    'congressional', 
+                    'judicial', 
+                    'state-house', 
+                    'state-senate'
+                )
+                AND ARRAY_LENGTH(regexp_split_to_array("Name", ';'), 1) = 2
+                AND "ParentReportingUnit_Id" = %s
         LIMIT   1
     """
-    ).fetchall()
-
-    unit_portions = q[0][0]
-    hierarchy = []
-    for i in range(len(unit_portions)):
-        unit = ";".join(unit_portions[0 : i + 1])
-        q = session.execute(
-            f"""
-            SELECT    "ReportingUnitType_Id"
-            FROM    "ReportingUnit"
-            WHERE    "Name" = '{unit}' 
-        """
-        ).fetchall()
-        hierarchy.append(q[0][0])
-    return hierarchy
+    )
+    connection = session.bind.raw_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(q, [jurisdiction_id])
+        result = cursor.fetchall()
+        subdivision_type_id = result[0][0]
+    except:
+        subdivision_type_id = None
+    cursor.close()
+    return subdivision_type_id
 
 
 def get_candidate_votecounts(session, election_id, top_ru_id, subdivision_type_id):

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -961,25 +961,6 @@ def get_input_options(session, input, verbose):
         return result
 
 
-# TODO: remove when the data export functionality is worked on
-def get_datafile_info(session, results_file):
-    q = session.execute(
-        f"""
-        SELECT "Id", "Election_Id" 
-        FROM _datafile 
-        WHERE file_name = '{results_file}'
-        """
-    ).fetchall()
-    try:
-        return q[0]
-    except IndexError:
-        print(
-            f"No record named {results_file} found in _datafile table in {session.bind.url}"
-        )
-        return [0, 0]
-    return q[0]
-
-
 def candidate_to_id(session, name):
     """fuzzy string matching on name field, may return multiple results"""
     name_field = get_name_field("Candidate")


### PR DESCRIPTION
Closes #110 , #35 
- Uses length of reporting unit name (split to array) to determine type of reporting unit one level down from jurisdiction
- Deletes out unused code
- Updates the `export_outlier_data` to include the election as a parameter