### PR TITLE
Issue187 select all of contest type

### DIFF
--- a/src/election_data_analysis/analyze/__init__.py
+++ b/src/election_data_analysis/analyze/__init__.py
@@ -309,7 +309,10 @@ def create_bar(
 
     if contest_type:
         unsummed = unsummed[unsummed["contest_district_type"] == contest_type]
-    if contest:
+    # through front end, contest_type must be truthy if contest is truthy
+    # Only filter when there is an actual contest passed through, as opposed to 
+    # "All congressional" as an example
+    if contest and contest[0:3] != "All":
         unsummed = unsummed[unsummed["Contest"] == contest]
 
     groupby_cols = [

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -82,6 +82,8 @@ US Virgin Islands"""
 
 db_pars = ["host", "port", "dbname", "user", "password"]
 
+contest_types_model = ["state", "congressional", "judicial", "state-house", "state-senate"]
+
 
 def get_database_names(con):
     """Return dataframe with one column called `datname` """
@@ -909,6 +911,7 @@ def get_filtered_input_options(session, input_str, filters):
         }
         df = pd.DataFrame(data=data)
     elif input_str == "contest":
+        contest_type
         contest_df = get_relevant_contests(session, filters)
         df = contest_df[contest_df["type"].isin(filters)]
     # Assume these others are candidate searching. This is handled differently
@@ -1046,12 +1049,7 @@ def get_jurisdiction_hierarchy(session, jurisdiction_id):
         FROM    "ComposingReportingUnitJoin" cruj
                 JOIN "ReportingUnit" ru on cruj."ChildReportingUnit_Id" = ru."Id"
                 JOIN "ReportingUnitType" rut on ru."ReportingUnitType_Id" = rut."Id"
-        WHERE   rut."Txt" not in (
-                    'congressional', 
-                    'judicial', 
-                    'state-house', 
-                    'state-senate'
-                )
+        WHERE   rut."Txt" not in %s
                 AND ARRAY_LENGTH(regexp_split_to_array("Name", ';'), 1) = 2
                 AND "ParentReportingUnit_Id" = %s
         LIMIT   1
@@ -1060,7 +1058,7 @@ def get_jurisdiction_hierarchy(session, jurisdiction_id):
     connection = session.bind.raw_connection()
     cursor = connection.cursor()
     try:
-        cursor.execute(q, [jurisdiction_id])
+        cursor.execute(q, [tuple(contest_types_model), jurisdiction_id])
         result = cursor.fetchall()
         subdivision_type_id = result[0][0]
     except:

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -911,9 +911,22 @@ def get_filtered_input_options(session, input_str, filters):
         }
         df = pd.DataFrame(data=data)
     elif input_str == "contest":
-        contest_type
+        contest_type = list(set(contest_types_model) & set(filters))[0]
+
+        connection = session.bind.raw_connection()
+        cursor = connection.cursor()
+        reporting_unit_id = list_to_id(session, "ReportingUnit", filters)
+        reporting_unit = name_from_id(cursor, "ReportingUnit", reporting_unit_id)
+        connection.close()
+
+        contest_type_df = pd.DataFrame([{
+            "parent": reporting_unit,
+            "name": f"All {contest_type}",
+            "type": contest_type
+        }])
         contest_df = get_relevant_contests(session, filters)
-        df = contest_df[contest_df["type"].isin(filters)]
+        contest_df = contest_df[contest_df["type"].isin(filters)]
+        df = pd.concat([contest_type_df, contest_df])
     # Assume these others are candidate searching. This is handled differently
     # because the results variable is structured slightly differently
     elif input_str == "subdivision_type":


### PR DESCRIPTION
Close #187
- Display `All <contest type>` as option for user when displaying contests
- Only filter on a contest when it's the name of a real one. Otherwise will only display on that contest type