### PR TITLE
Issue217: NaN in scatter plot return

### DIFF
--- a/src/election_data_analysis/analyze/__init__.py
+++ b/src/election_data_analysis/analyze/__init__.py
@@ -187,6 +187,10 @@ def create_scatter(
     pivot_df = pd.pivot_table(
         unsummed, values="Count", index=["Name"], columns="Selection"
     ).reset_index()
+    pivot_df = pivot_df.dropna()
+    if pivot_df.empty:
+        connection.close()
+        return None
 
     # package up results
     results = package_results(pivot_df, jurisdiction, x, y)


### PR DESCRIPTION
Close #217 
- Drop rows that are NaN before packaging results. This data is a result of selecting two candidates that never overlap in a single county.