### PR TITLE
Issue345 simplify jp ini

### DIFF
--- a/src/parameter_file_templates/jurisdiction_prep.ini.template
+++ b/src/parameter_file_templates/jurisdiction_prep.ini.template
@@ -1,6 +1,4 @@
 [election_data_analysis]
-mungers_dir=</path/to/directory/holding/individual/munger/directories>
-jurisdiction_path=<path/to/folder/containing/jurisdiction/definition/files>
 name=<internal db name from ReportingUnit table>
 reporting_unit_type=<type of reporting unit named above, typically state>
 abbreviated_name=<2 character abbreviation for name>


### PR DESCRIPTION
Closes #345 

Simplifies jurisdiction_prep.ini file to remove system-dependent info (which is now read from run_time.ini). E.g.:

```
[election_data_analysis]
name=Oregon
reporting_unit_type=state
abbreviated_name=OR
count_of_state_house_districts=60
count_of_state_senate_districts=30
count_of_us_house_districts=5
```