### PR TITLE
Nist xml

### DIFF
--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -547,7 +547,8 @@ If there are hidden columns in an Excel file, you may need to omit the hidden co
 
 ### NIST Common Data Format imports and exports
 To import results from a file that is valid NIST V2 xml -- that can be formally validated against the [NIST election results reporting schema (Version 2)](https://github.com/usnistgov/ElectionResultsReporting/raw/version2/NIST_V2_election_results_reporting.xsd) -- use the file_type 'nist_v2_xml'
-Note: some xml files (e.g., Ohio 2020 General) loosely follow the nist format but not enough to be validated. Our convention is that if the munger name contains "nist" and the file_type is xml, then the system will look for a namespace declaration.
+
+Some xml files (e.g., Ohio 2020 General) use the older Version 1 common data format. Our convention is that if the munger name contains "nist" and the file_type is xml, then the system will look for a namespace declaration.
 
 This package also provides functionality to export the data according to the [NIST election results reporting schema (Version 2)](https://github.com/usnistgov/ElectionResultsReporting/raw/version2/NIST_V2_election_results_reporting.xsd). This is as simple as identifying an election and jurisdiction of interest:
 ```

--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -29,9 +29,9 @@ Party=Total Votes Cast
 ```
 and similarly, if necessary, for any Contest or Selection. If there is more than one Party (e.g.) to be ignored, use a comma-separated list: `Candidate=Total Votes Cast,Registered Voters`
  
- There is one required parameters: `file_type`. For any file type other than valid_nist_xml, there are two more required parameters: `count_locations` and `munge_strings`. Depending on the values of these, there are other required and optional fields. 
+ There is one required parameters: `file_type`. For any file type other than nist_v2_xml, there are two more required parameters: `count_locations` and `munge_strings`. Depending on the values of these, there are other required and optional fields. 
  `file_type`: controls which pandas function reads the file contents. Related optional and required parameters must be given under the `[file_type]` header.
-   * 'valid_nist_xml' for xml-formatted file that obeys the [NIST Common Data Format schema](http://itl.nist.gov/ns/voting/1500-100/v2). For this file_type, no other parameters are needed. If there are no items to ignore, use the munger [valid_nist_xml](mungers/valid_nist_xml.munger). Otherwise, use a revised version of that munger, with an `[ignore]` section added.
+   * 'nist_v2_xml' for xml-formatted file that obeys the [NIST Common Data Format schema](http://itl.nist.gov/ns/voting/1500-100/v2). For this file_type, no other parameters are needed. If there are no items to ignore, use the munger [nist_v2_xml](mungers/nist_v2_xml.munger). Otherwise, use a revised version of that munger, with an `[ignore]` section added.
    * 'excel'
     * (optional) a list `sheets_to_read_names` (and/or `sheets_to_read_numbers`) of spreadsheets to read, 
     * (optional) a list `sheets_to_skip_names` of names of spreadsheets to skip
@@ -546,7 +546,7 @@ If not all rows are data, and some string fields to be munged have blank headers
 If there are hidden columns in an Excel file, you may need to omit the hidden columns from various counts.
 
 ### NIST Common Data Format imports and exports
-To import results from a file that is valid NIST xml -- that can be formally validated against the [NIST election results reporting schema (Version 2)](https://github.com/usnistgov/ElectionResultsReporting/raw/version2/NIST_V2_election_results_reporting.xsd) -- use the file_type 'valid_nist_xml'
+To import results from a file that is valid NIST V2 xml -- that can be formally validated against the [NIST election results reporting schema (Version 2)](https://github.com/usnistgov/ElectionResultsReporting/raw/version2/NIST_V2_election_results_reporting.xsd) -- use the file_type 'nist_v2_xml'
 Note: some xml files (e.g., Ohio 2020 General) loosely follow the nist format but not enough to be validated. Our convention is that if the munger name contains "nist" and the file_type is xml, then the system will look for a namespace declaration.
 
 This package also provides functionality to export the data according to the [NIST election results reporting schema (Version 2)](https://github.com/usnistgov/ElectionResultsReporting/raw/version2/NIST_V2_election_results_reporting.xsd). This is as simple as identifying an election and jurisdiction of interest:

--- a/src/election_data_analysis/__init__.py
+++ b/src/election_data_analysis/__init__.py
@@ -1460,7 +1460,7 @@ class Analyzer:
 
     def export_nist(self, election: str, jurisdiction: str) -> str:
         xml_string = et.tostring(
-            nist.nist_xml_export_tree(
+            nist.nist_v2_xml_export_tree(
                 self.session, election, jurisdiction,
                 issuer=nist.default_issuer,
                 issuer_abbreviation=nist.default_issuer_abbreviation,

--- a/src/election_data_analysis/__init__.py
+++ b/src/election_data_analysis/__init__.py
@@ -361,7 +361,7 @@ class DataLoader:
         cursor = connection.cursor()
 
         # find all datafile ids matching the given election and jurisdiction
-        df_list, err_str = db.data_file_list(
+        df_list, err_str = db.data_file_list_cursor(
             cursor, election_id, reporting_unit_id=juris_id
         )
         if err_str:
@@ -1495,7 +1495,7 @@ def aggregate_results(
     connection = an.session.bind.raw_connection()
     cursor = connection.cursor()
 
-    datafile_list, e = db.data_file_list(
+    datafile_list, e = db.data_file_list_cursor(
         cursor,
         election_id,
         reporting_unit_id=jurisdiction_id,

--- a/src/election_data_analysis/__init__.py
+++ b/src/election_data_analysis/__init__.py
@@ -1458,10 +1458,16 @@ class Analyzer:
 
         return election_report
 
-    def export_nist(self, election: str, jurisdiction: str) -> str:
+    def export_nist(
+            self,
+            election: str,
+            jurisdiction: str,
+            major_subdivision: Optional[str] = None,
+    ) -> str:
         xml_string = et.tostring(
             nist.nist_v2_xml_export_tree(
                 self.session, election, jurisdiction,
+                major_subdivision=major_subdivision,
                 issuer=nist.default_issuer,
                 issuer_abbreviation=nist.default_issuer_abbreviation,
                 status=nist.default_status,

--- a/src/election_data_analysis/analyze/__init__.py
+++ b/src/election_data_analysis/analyze/__init__.py
@@ -57,7 +57,7 @@ def create_rollup(
     connection = session.bind.raw_connection()
     cursor = connection.cursor()
     if not datafile_list:
-        datafile_list, e = db.data_file_list(cursor, election_id, by="Id")
+        datafile_list, e = db.data_file_list_cursor(cursor,election_id,by="Id")
         if e:
             return e
         by = "Id"

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -712,7 +712,7 @@ def vote_type_list(cursor, datafile_list: list, by: str = "Id") -> (list, str):
     return vt_list, err_str
 
 
-def data_file_list(
+def data_file_list_cursor(
     cursor, election_id, reporting_unit_id: Optional[int] = None, by="Id"
 ):
     q = sql.SQL(
@@ -730,6 +730,17 @@ def data_file_list(
     except Exception as exc:
         err_str = f"Database error pulling list of datafiles with election id in {election_id}: {exc}"
         df_list = None
+    return df_list, err_str
+
+def data_file_list(
+        session, election_id, reporting_unit_id: Optional[int] = None, by: str = "Id",
+) -> (list, str):
+    connection = session.bind.raw_connection()
+    cursor = connection.cursor()
+    df_list, err_str = data_file_list_cursor(
+        cursor, election_id, reporting_unit_id=reporting_unit_id, by=by
+    )
+    connection.close()
     return df_list, err_str
 
 

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -883,8 +883,11 @@ def get_relevant_contests(session, filters):
 
 
 def get_jurisdiction_hierarchy(session, jurisdiction_id):
-    """get type of reporting unit one level down from jurisdiction.
-    Omit particular types that are contest types, not true reporting unit types"""
+    """get reporting unit type id of reporting unit one level down from jurisdiction.
+    Omit particular types that are contest types, not true reporting unit types
+    TODO: handle case where type is non-standard and some other smaller reporting units are also
+    also non-standard
+    """
     q = sql.SQL(
         """
         SELECT  *

--- a/src/election_data_analysis/database/__init__.py
+++ b/src/election_data_analysis/database/__init__.py
@@ -1196,8 +1196,8 @@ def export_rollup_from_db(
     ).format(
         count_item_type_sql=count_item_type_sql,
         by=sql.Identifier(by),
-        group_and_order_by=sql.SQL(group_and_order_by),
-        restrict=sql.SQL(restrict),
+        group_and_order_by=group_and_order_by,
+        restrict=restrict,
         selection=selection,
         selection_join=selection_join,
         election_district_join=election_district_join,

--- a/src/election_data_analysis/munge/__init__.py
+++ b/src/election_data_analysis/munge/__init__.py
@@ -56,7 +56,7 @@ munger_dependent_reqs: Dict[str, Dict[str, List[str]]] = {
 req_munger_parameters: Dict[str, Dict[str, Any]] = {
     "file_type": {
         "data_type": "string",
-        "allowed_values": ["excel", "json-nested", "xml", "flat_text", "valid_nist_xml"]},
+        "allowed_values": ["excel", "json-nested", "xml", "flat_text", "nist_v2_xml"]},
 }
 
 opt_munger_param_values: Dict[str, List[str]] = {
@@ -909,7 +909,7 @@ def raw_to_id_simple(
                 drop = False
             if t == "CountItemType":
                 # munge raw to internal CountItemType
-                if file_type == "valid_nist_xml":
+                if file_type == "nist_v2_xml":
                     r_i = sf.cit_from_raw_nist_df
                 else:
                     r_i = pd.read_csv(
@@ -1923,9 +1923,9 @@ def file_to_raw_df(
     err = None
     file_name = Path(f_path).name
 
-    if p["file_type"] == "valid_nist_xml":
+    if p["file_type"] == "nist_v2_xml":
         try:
-            df, err = sf.read_valid_nist_xml(f_path)
+            df, err = sf.read_nist_v2_xml(f_path)
             if ui.fatal_error(err):
                 return pd.DataFrame(), err
         except Exception as exc:

--- a/src/election_data_analysis/munge/__init__.py
+++ b/src/election_data_analysis/munge/__init__.py
@@ -1925,7 +1925,7 @@ def file_to_raw_df(
 
     if p["file_type"] == "nist_v2_xml":
         try:
-            df, err = sf.read_nist_v2_xml(f_path)
+            df, err = sf.read_nist_xml(f_path)
             if ui.fatal_error(err):
                 return pd.DataFrame(), err
         except Exception as exc:

--- a/src/election_data_analysis/nist_export/__init__.py
+++ b/src/election_data_analysis/nist_export/__init__.py
@@ -19,10 +19,7 @@ schema_location = "https://github.com/usnistgov/ElectionResultsReporting/raw/ver
 namespace = "http://itl.nist.gov/ns/voting/1500-100/v2"
 
 
-
-
-
-def nist_xml_export_tree(
+def nist_v2_xml_export_tree(
         session: Session,
         election: str,
         jurisdiction: str,
@@ -31,10 +28,10 @@ def nist_xml_export_tree(
         status: str = default_status,
         vendor_application_id: str = default_vendor_application_id
 ) -> et.ElementTree:
-    """Creates a tree in the NIST common data format containing the results
+    """Creates a tree in the NIST common data format (V2) containing the results
     from the given election and jurisdiction. Note that all available results will
     be exported. I.e., if database has precinct-level results, the tree will
-    contain precinct-level results."""
+    contain precinct-level results. See"""
     # set up
     election_id = db.name_to_id(session, "Election", election)
     jurisdiction_id = db.name_to_id(session, "ReportingUnit", jurisdiction)
@@ -193,10 +190,10 @@ def nist_xml_export_tree(
 
 
 def read_vote_count_nist(
-    session,
-    election_id,
-    reporting_unit_id,
-):
+    session: Session,
+    election_id: int,
+    reporting_unit_id: int,
+) ->  pd.DataFrame:
     """The VoteCount table is the only place that maps contests to a specific
     election. But this table is the largest one, so we don't want to use pandas methods
     to read into a DF and then filter"""
@@ -246,3 +243,11 @@ def read_vote_count_nist(
     return results_df
 
 
+def read_vote_count_nist_NEW(
+        session: Session,
+        election: str,
+        jurisdiction: str,
+        subunit_type: str = "county",
+) -> pd.DataFrame:
+
+    return results_df

--- a/src/election_data_analysis/nist_export/__init__.py
+++ b/src/election_data_analysis/nist_export/__init__.py
@@ -1,12 +1,12 @@
 import xml.etree.ElementTree as et
-from typing import Optional, List, Dict, Any
+from typing import Optional
 import pandas as pd
 from sqlalchemy.orm import Session
 from psycopg2 import sql
 from datetime import datetime, timezone
 from election_data_analysis import (
-    analyze as an,
     database as db,
+    analyze as an,
 )
 
 # constants set by issuer
@@ -244,7 +244,7 @@ def read_vote_count_nist(
     unrolled_df = pd.DataFrame(results, columns=fields)
 
     if rollup_ru_type:
-        results_df, err_str = rollup(
+        results_df, err_str = an.rollup(
             session,
             unrolled_df,
             "Count",
@@ -260,34 +260,4 @@ def read_vote_count_nist(
         results_df = unrolled_df
     return results_df
 
-
-def rollup(
-        session, df:pd.DataFrame,
-        count_col:str,
-        ru_id_column: str,
-        new_ru_id_column: str,
-        rollup_rut: str = "county",
-        ignore: Optional[List] = None
-) -> (pd.DataFrame(), Optional[dict]):
-    err = None  # TODO error handline
-    if ignore:
-        working = df.copy().drop(ignore, axis=1)
-    group_cols = [
-        c for c in working.columns
-        if (c not in (ru_id_column,count_col))
-    ]
-    parents, err_str = db.parents(session,df[ru_id_column].unique(), subunit_type=rollup_rut)
-
-    working = working.merge(
-        parents, how='left', left_on=ru_id_column, right_on="child_id"
-    )[group_cols + ["parent_id", count_col]]
-
-    rut_name = rollup_rut.replace(" ","-")
-    rollup_df = working.groupby(
-        group_cols + ["parent_id"]
-    ).sum(count_col).reset_index().rename(
-        columns={"parent_id": new_ru_id_column}
-    )
-
-    return rollup_df, err
 

--- a/src/election_data_analysis/special_formats/__init__.py
+++ b/src/election_data_analysis/special_formats/__init__.py
@@ -403,7 +403,7 @@ def replace_id_values(df, f_path):
     return df
 
 
-def read_valid_nist_xml(f_path: str) -> (pd.DataFrame, Optional[Dict]):
+def read_nist_xml(f_path: str) -> (pd.DataFrame,Optional[Dict]):
     err = None
     # TODO add error handling
     try:

--- a/src/election_data_analysis/special_formats/__init__.py
+++ b/src/election_data_analysis/special_formats/__init__.py
@@ -451,7 +451,7 @@ def read_nist_xml(f_path: str) -> (pd.DataFrame,Optional[Dict]):
             vc_dict["CandidateId"] = con_sel.find(f"{{{ns}}}CandidateIds").text
             for vc in con_sel.findall(f"{{{ns}}}VoteCounts"):
                 vc_dict.update({
-                    "Count": vc.find(f"{{{ns}}}Count").text,
+                    "Count": int(vc.find(f"{{{ns}}}Count").text),
                     "CountItemType": vc.find(f"{{{ns}}}Type").text,
                     "GpUnitId": vc.find(f"{{{ns}}}GpUnitId").text,
                 })

--- a/src/ini_files_for_results/Delaware/de_20g_nist_export.ini
+++ b/src/ini_files_for_results/Delaware/de_20g_nist_export.ini
@@ -1,7 +1,7 @@
 [election_data_analysis]
 results_file=Delaware/nist_from_scratch.xml
 jurisdiction_directory=Delaware
-munger_name=valid_nist_xml
+munger_name=nist_v2_xml
 top_reporting_unit=Delaware
 election=2020 General
 results_short_name=test_nist_export

--- a/src/ini_files_for_results/North-Carolina/nc_20g_nist_export_by_county.ini
+++ b/src/ini_files_for_results/North-Carolina/nc_20g_nist_export_by_county.ini
@@ -1,0 +1,14 @@
+[election_data_analysis]
+results_file=North-Carolina/NC_2020g_by_county.xml
+jurisdiction_directory=North-Carolina
+munger_name=nist_v2_xml
+top_reporting_unit=North Carolina
+election=2020 General
+results_short_name=test_nist_export
+results_download_date=2021-03-02
+results_source=Stephanie
+results_note=test nist export from our system
+is_preliminary=False
+
+
+

--- a/src/jurisdictions/North-Carolina/dictionary.txt
+++ b/src/jurisdictions/North-Carolina/dictionary.txt
@@ -1,5 +1,6 @@
 cdf_element	cdf_internal_name	raw_identifier_value
 CandidateContest	NC Supreme Court Chief Justice	NC SUPREME COURT CHIEF JUSTICE SEAT 01
+CandidateContest	NC Supreme Court Chief Justice	NC Supreme Court Chief Justice
 CandidateContest	NC House District 1 (Democratic Party)	NC HOUSE OF REPRESENTATIVES DISTRICT 001 (DEM)
 CandidateContest	NC House District 2 (Democratic Party)	NC HOUSE OF REPRESENTATIVES DISTRICT 002 (DEM)
 CandidateContest	NC House District 3 (Democratic Party)	NC HOUSE OF REPRESENTATIVES DISTRICT 003 (DEM)
@@ -1231,208 +1232,310 @@ CandidateContest	NC Commissioner of Labor (Constitution Party)	NC COMMISSIONER O
 CandidateContest	NC Auditor (Constitution Party)	NC AUDITOR (CST)
 CandidateContest	NC Secretary of State (Constitution Party)	NC SECRETARY OF STATE (CST)
 CandidateContest	NC House District 1	NC HOUSE OF REPRESENTATIVES DISTRICT 001
+CandidateContest	NC House District 1	NC House District 1
 CandidateContest	NC House District 2	NC HOUSE OF REPRESENTATIVES DISTRICT 002
 CandidateContest	NC House District 3	NC HOUSE OF REPRESENTATIVES DISTRICT 003
+CandidateContest	NC House District 3	NC House District 3
 CandidateContest	NC House District 4	NC HOUSE OF REPRESENTATIVES DISTRICT 004
 CandidateContest	NC House District 5	NC HOUSE OF REPRESENTATIVES DISTRICT 005
+CandidateContest	NC House District 5	NC House District 5
 CandidateContest	NC House District 6	NC HOUSE OF REPRESENTATIVES DISTRICT 006
 CandidateContest	NC House District 7	NC HOUSE OF REPRESENTATIVES DISTRICT 007
+CandidateContest	NC House District 7	NC House District 7
 CandidateContest	NC House District 8	NC HOUSE OF REPRESENTATIVES DISTRICT 008
 CandidateContest	NC House District 9	NC HOUSE OF REPRESENTATIVES DISTRICT 009
+CandidateContest	NC House District 9	NC House District 9
 CandidateContest	NC House District 10	NC HOUSE OF REPRESENTATIVES DISTRICT 010
 CandidateContest	NC House District 11	NC HOUSE OF REPRESENTATIVES DISTRICT 011
+CandidateContest	NC House District 11	NC House District 11
 CandidateContest	NC House District 12	NC HOUSE OF REPRESENTATIVES DISTRICT 012
 CandidateContest	NC House District 13	NC HOUSE OF REPRESENTATIVES DISTRICT 013
+CandidateContest	NC House District 13	NC House District 13
 CandidateContest	NC House District 14	NC HOUSE OF REPRESENTATIVES DISTRICT 014
 CandidateContest	NC House District 15	NC HOUSE OF REPRESENTATIVES DISTRICT 015
+CandidateContest	NC House District 15	NC House District 15
 CandidateContest	NC House District 16	NC HOUSE OF REPRESENTATIVES DISTRICT 016
 CandidateContest	NC House District 17	NC HOUSE OF REPRESENTATIVES DISTRICT 017
+CandidateContest	NC House District 17	NC House District 17
 CandidateContest	NC House District 18	NC HOUSE OF REPRESENTATIVES DISTRICT 018
 CandidateContest	NC House District 19	NC HOUSE OF REPRESENTATIVES DISTRICT 019
+CandidateContest	NC House District 19	NC House District 19
 CandidateContest	NC House District 20	NC HOUSE OF REPRESENTATIVES DISTRICT 020
 CandidateContest	NC House District 21	NC HOUSE OF REPRESENTATIVES DISTRICT 021
+CandidateContest	NC House District 21	NC House District 21
 CandidateContest	NC House District 22	NC HOUSE OF REPRESENTATIVES DISTRICT 022
 CandidateContest	NC House District 23	NC HOUSE OF REPRESENTATIVES DISTRICT 023
+CandidateContest	NC House District 23	NC House District 23
 CandidateContest	NC House District 24	NC HOUSE OF REPRESENTATIVES DISTRICT 024
 CandidateContest	NC House District 25	NC HOUSE OF REPRESENTATIVES DISTRICT 025
+CandidateContest	NC House District 25	NC House District 25
 CandidateContest	NC House District 26	NC HOUSE OF REPRESENTATIVES DISTRICT 026
 CandidateContest	NC House District 27	NC HOUSE OF REPRESENTATIVES DISTRICT 027
+CandidateContest	NC House District 27	NC House District 27
 CandidateContest	NC House District 28	NC HOUSE OF REPRESENTATIVES DISTRICT 028
 CandidateContest	NC House District 29	NC HOUSE OF REPRESENTATIVES DISTRICT 029
+CandidateContest	NC House District 29	NC House District 29
 CandidateContest	NC House District 30	NC HOUSE OF REPRESENTATIVES DISTRICT 030
 CandidateContest	NC House District 31	NC HOUSE OF REPRESENTATIVES DISTRICT 031
+CandidateContest	NC House District 31	NC House District 31
 CandidateContest	NC House District 32	NC HOUSE OF REPRESENTATIVES DISTRICT 032
 CandidateContest	NC House District 33	NC HOUSE OF REPRESENTATIVES DISTRICT 033
+CandidateContest	NC House District 33	NC House District 33
 CandidateContest	NC House District 34	NC HOUSE OF REPRESENTATIVES DISTRICT 034
 CandidateContest	NC House District 35	NC HOUSE OF REPRESENTATIVES DISTRICT 035
+CandidateContest	NC House District 35	NC House District 35
 CandidateContest	NC House District 36	NC HOUSE OF REPRESENTATIVES DISTRICT 036
 CandidateContest	NC House District 37	NC HOUSE OF REPRESENTATIVES DISTRICT 037
+CandidateContest	NC House District 37	NC House District 37
 CandidateContest	NC House District 38	NC HOUSE OF REPRESENTATIVES DISTRICT 038
 CandidateContest	NC House District 39	NC HOUSE OF REPRESENTATIVES DISTRICT 039
+CandidateContest	NC House District 39	NC House District 39
 CandidateContest	NC House District 40	NC HOUSE OF REPRESENTATIVES DISTRICT 040
 CandidateContest	NC House District 41	NC HOUSE OF REPRESENTATIVES DISTRICT 041
+CandidateContest	NC House District 41	NC House District 41
 CandidateContest	NC House District 42	NC HOUSE OF REPRESENTATIVES DISTRICT 042
 CandidateContest	NC House District 43	NC HOUSE OF REPRESENTATIVES DISTRICT 043
+CandidateContest	NC House District 43	NC House District 43
 CandidateContest	NC House District 44	NC HOUSE OF REPRESENTATIVES DISTRICT 044
 CandidateContest	NC House District 45	NC HOUSE OF REPRESENTATIVES DISTRICT 045
+CandidateContest	NC House District 45	NC House District 45
 CandidateContest	NC House District 46	NC HOUSE OF REPRESENTATIVES DISTRICT 046
 CandidateContest	NC House District 47	NC HOUSE OF REPRESENTATIVES DISTRICT 047
+CandidateContest	NC House District 47	NC House District 47
 CandidateContest	NC House District 48	NC HOUSE OF REPRESENTATIVES DISTRICT 048
 CandidateContest	NC House District 49	NC HOUSE OF REPRESENTATIVES DISTRICT 049
+CandidateContest	NC House District 49	NC House District 49
 CandidateContest	NC House District 50	NC HOUSE OF REPRESENTATIVES DISTRICT 050
 CandidateContest	NC House District 51	NC HOUSE OF REPRESENTATIVES DISTRICT 051
+CandidateContest	NC House District 51	NC House District 51
 CandidateContest	NC House District 52	NC HOUSE OF REPRESENTATIVES DISTRICT 052
 CandidateContest	NC House District 53	NC HOUSE OF REPRESENTATIVES DISTRICT 053
+CandidateContest	NC House District 53	NC House District 53
 CandidateContest	NC House District 54	NC HOUSE OF REPRESENTATIVES DISTRICT 054
 CandidateContest	NC House District 55	NC HOUSE OF REPRESENTATIVES DISTRICT 055
+CandidateContest	NC House District 55	NC House District 55
 CandidateContest	NC House District 56	NC HOUSE OF REPRESENTATIVES DISTRICT 056
 CandidateContest	NC House District 57	NC HOUSE OF REPRESENTATIVES DISTRICT 057
+CandidateContest	NC House District 57	NC House District 57
 CandidateContest	NC House District 58	NC HOUSE OF REPRESENTATIVES DISTRICT 058
 CandidateContest	NC House District 59	NC HOUSE OF REPRESENTATIVES DISTRICT 059
+CandidateContest	NC House District 59	NC House District 59
 CandidateContest	NC House District 60	NC HOUSE OF REPRESENTATIVES DISTRICT 060
 CandidateContest	NC House District 61	NC HOUSE OF REPRESENTATIVES DISTRICT 061
+CandidateContest	NC House District 61	NC House District 61
 CandidateContest	NC House District 62	NC HOUSE OF REPRESENTATIVES DISTRICT 062
 CandidateContest	NC House District 63	NC HOUSE OF REPRESENTATIVES DISTRICT 063
+CandidateContest	NC House District 63	NC House District 63
 CandidateContest	NC House District 64	NC HOUSE OF REPRESENTATIVES DISTRICT 064
 CandidateContest	NC House District 65	NC HOUSE OF REPRESENTATIVES DISTRICT 065
+CandidateContest	NC House District 65	NC House District 65
 CandidateContest	NC House District 66	NC HOUSE OF REPRESENTATIVES DISTRICT 066
 CandidateContest	NC House District 67	NC HOUSE OF REPRESENTATIVES DISTRICT 067
+CandidateContest	NC House District 67	NC House District 67
 CandidateContest	NC House District 68	NC HOUSE OF REPRESENTATIVES DISTRICT 068
 CandidateContest	NC House District 69	NC HOUSE OF REPRESENTATIVES DISTRICT 069
+CandidateContest	NC House District 69	NC House District 69
 CandidateContest	NC House District 70	NC HOUSE OF REPRESENTATIVES DISTRICT 070
 CandidateContest	NC House District 71	NC HOUSE OF REPRESENTATIVES DISTRICT 071
+CandidateContest	NC House District 71	NC House District 71
 CandidateContest	NC House District 72	NC HOUSE OF REPRESENTATIVES DISTRICT 072
 CandidateContest	NC House District 73	NC HOUSE OF REPRESENTATIVES DISTRICT 073
+CandidateContest	NC House District 73	NC House District 73
 CandidateContest	NC House District 74	NC HOUSE OF REPRESENTATIVES DISTRICT 074
 CandidateContest	NC House District 75	NC HOUSE OF REPRESENTATIVES DISTRICT 075
+CandidateContest	NC House District 75	NC House District 75
 CandidateContest	NC House District 76	NC HOUSE OF REPRESENTATIVES DISTRICT 076
 CandidateContest	NC House District 77	NC HOUSE OF REPRESENTATIVES DISTRICT 077
+CandidateContest	NC House District 77	NC House District 77
 CandidateContest	NC House District 78	NC HOUSE OF REPRESENTATIVES DISTRICT 078
 CandidateContest	NC House District 79	NC HOUSE OF REPRESENTATIVES DISTRICT 079
+CandidateContest	NC House District 79	NC House District 79
 CandidateContest	NC House District 80	NC HOUSE OF REPRESENTATIVES DISTRICT 080
 CandidateContest	NC House District 81	NC HOUSE OF REPRESENTATIVES DISTRICT 081
+CandidateContest	NC House District 81	NC House District 81
 CandidateContest	NC House District 82	NC HOUSE OF REPRESENTATIVES DISTRICT 082
 CandidateContest	NC House District 83	NC HOUSE OF REPRESENTATIVES DISTRICT 083
+CandidateContest	NC House District 83	NC House District 83
 CandidateContest	NC House District 84	NC HOUSE OF REPRESENTATIVES DISTRICT 084
 CandidateContest	NC House District 85	NC HOUSE OF REPRESENTATIVES DISTRICT 085
+CandidateContest	NC House District 85	NC House District 85
 CandidateContest	NC House District 86	NC HOUSE OF REPRESENTATIVES DISTRICT 086
 CandidateContest	NC House District 87	NC HOUSE OF REPRESENTATIVES DISTRICT 087
+CandidateContest	NC House District 87	NC House District 87
 CandidateContest	NC House District 88	NC HOUSE OF REPRESENTATIVES DISTRICT 088
 CandidateContest	NC House District 89	NC HOUSE OF REPRESENTATIVES DISTRICT 089
+CandidateContest	NC House District 89	NC House District 89
 CandidateContest	NC House District 90	NC HOUSE OF REPRESENTATIVES DISTRICT 090
 CandidateContest	NC House District 91	NC HOUSE OF REPRESENTATIVES DISTRICT 091
+CandidateContest	NC House District 91	NC House District 91
 CandidateContest	NC House District 92	NC HOUSE OF REPRESENTATIVES DISTRICT 092
 CandidateContest	NC House District 93	NC HOUSE OF REPRESENTATIVES DISTRICT 093
+CandidateContest	NC House District 93	NC House District 93
 CandidateContest	NC House District 94	NC HOUSE OF REPRESENTATIVES DISTRICT 094
 CandidateContest	NC House District 95	NC HOUSE OF REPRESENTATIVES DISTRICT 095
+CandidateContest	NC House District 95	NC House District 95
 CandidateContest	NC House District 96	NC HOUSE OF REPRESENTATIVES DISTRICT 096
 CandidateContest	NC House District 97	NC HOUSE OF REPRESENTATIVES DISTRICT 097
+CandidateContest	NC House District 97	NC House District 97
 CandidateContest	NC House District 98	NC HOUSE OF REPRESENTATIVES DISTRICT 098
 CandidateContest	NC House District 99	NC HOUSE OF REPRESENTATIVES DISTRICT 099
+CandidateContest	NC House District 99	NC House District 99
 CandidateContest	NC House District 100	NC HOUSE OF REPRESENTATIVES DISTRICT 100
 CandidateContest	NC House District 101	NC HOUSE OF REPRESENTATIVES DISTRICT 101
+CandidateContest	NC House District 101	NC House District 101
 CandidateContest	NC House District 102	NC HOUSE OF REPRESENTATIVES DISTRICT 102
 CandidateContest	NC House District 103	NC HOUSE OF REPRESENTATIVES DISTRICT 103
+CandidateContest	NC House District 103	NC House District 103
 CandidateContest	NC House District 104	NC HOUSE OF REPRESENTATIVES DISTRICT 104
 CandidateContest	NC House District 105	NC HOUSE OF REPRESENTATIVES DISTRICT 105
+CandidateContest	NC House District 105	NC House District 105
 CandidateContest	NC House District 106	NC HOUSE OF REPRESENTATIVES DISTRICT 106
 CandidateContest	NC House District 107	NC HOUSE OF REPRESENTATIVES DISTRICT 107
+CandidateContest	NC House District 107	NC House District 107
 CandidateContest	NC House District 108	NC HOUSE OF REPRESENTATIVES DISTRICT 108
 CandidateContest	NC House District 109	NC HOUSE OF REPRESENTATIVES DISTRICT 109
+CandidateContest	NC House District 109	NC House District 109
 CandidateContest	NC House District 110	NC HOUSE OF REPRESENTATIVES DISTRICT 110
 CandidateContest	NC House District 111	NC HOUSE OF REPRESENTATIVES DISTRICT 111
+CandidateContest	NC House District 111	NC House District 111
 CandidateContest	NC House District 112	NC HOUSE OF REPRESENTATIVES DISTRICT 112
 CandidateContest	NC House District 113	NC HOUSE OF REPRESENTATIVES DISTRICT 113
+CandidateContest	NC House District 113	NC House District 113
 CandidateContest	NC House District 114	NC HOUSE OF REPRESENTATIVES DISTRICT 114
 CandidateContest	NC House District 115	NC HOUSE OF REPRESENTATIVES DISTRICT 115
+CandidateContest	NC House District 115	NC House District 115
 CandidateContest	NC House District 116	NC HOUSE OF REPRESENTATIVES DISTRICT 116
 CandidateContest	NC House District 117	NC HOUSE OF REPRESENTATIVES DISTRICT 117
+CandidateContest	NC House District 117	NC House District 117
 CandidateContest	NC House District 118	NC HOUSE OF REPRESENTATIVES DISTRICT 118
 CandidateContest	NC House District 119	NC HOUSE OF REPRESENTATIVES DISTRICT 119
+CandidateContest	NC House District 119	NC House District 119
 CandidateContest	NC House District 120	NC HOUSE OF REPRESENTATIVES DISTRICT 120
 CandidateContest	NC Senate District 1	NC STATE SENATE DISTRICT 01
+CandidateContest	NC Senate District 1	NC Senate District 1
 CandidateContest	NC Senate District 2	NC STATE SENATE DISTRICT 02
 CandidateContest	NC Senate District 3	NC STATE SENATE DISTRICT 03
+CandidateContest	NC Senate District 3	NC Senate District 3
 CandidateContest	NC Senate District 4	NC STATE SENATE DISTRICT 04
 CandidateContest	NC Senate District 5	NC STATE SENATE DISTRICT 05
+CandidateContest	NC Senate District 5	NC Senate District 5
 CandidateContest	NC Senate District 6	NC STATE SENATE DISTRICT 06
 CandidateContest	NC Senate District 7	NC STATE SENATE DISTRICT 07
+CandidateContest	NC Senate District 7	NC Senate District 7
 CandidateContest	NC Senate District 8	NC STATE SENATE DISTRICT 08
 CandidateContest	NC Senate District 9	NC STATE SENATE DISTRICT 09
+CandidateContest	NC Senate District 9	NC Senate District 9
 CandidateContest	NC Senate District 10	NC STATE SENATE DISTRICT 10
 CandidateContest	NC Senate District 11	NC STATE SENATE DISTRICT 11
+CandidateContest	NC Senate District 11	NC Senate District 11
 CandidateContest	NC Senate District 12	NC STATE SENATE DISTRICT 12
 CandidateContest	NC Senate District 13	NC STATE SENATE DISTRICT 13
+CandidateContest	NC Senate District 13	NC Senate District 13
 CandidateContest	NC Senate District 14	NC STATE SENATE DISTRICT 14
 CandidateContest	NC Senate District 15	NC STATE SENATE DISTRICT 15
+CandidateContest	NC Senate District 15	NC Senate District 15
 CandidateContest	NC Senate District 16	NC STATE SENATE DISTRICT 16
 CandidateContest	NC Senate District 17	NC STATE SENATE DISTRICT 17
+CandidateContest	NC Senate District 17	NC Senate District 17
 CandidateContest	NC Senate District 18	NC STATE SENATE DISTRICT 18
 CandidateContest	NC Senate District 19	NC STATE SENATE DISTRICT 19
+CandidateContest	NC Senate District 19	NC Senate District 19
 CandidateContest	NC Senate District 20	NC STATE SENATE DISTRICT 20
 CandidateContest	NC Senate District 21	NC STATE SENATE DISTRICT 21
+CandidateContest	NC Senate District 21	NC Senate District 21
 CandidateContest	NC Senate District 22	NC STATE SENATE DISTRICT 22
 CandidateContest	NC Senate District 23	NC STATE SENATE DISTRICT 23
+CandidateContest	NC Senate District 23	NC Senate District 23
 CandidateContest	NC Senate District 24	NC STATE SENATE DISTRICT 24
 CandidateContest	NC Senate District 25	NC STATE SENATE DISTRICT 25
+CandidateContest	NC Senate District 25	NC Senate District 25
 CandidateContest	NC Senate District 26	NC STATE SENATE DISTRICT 26
 CandidateContest	NC Senate District 27	NC STATE SENATE DISTRICT 27
+CandidateContest	NC Senate District 27	NC Senate District 27
 CandidateContest	NC Senate District 28	NC STATE SENATE DISTRICT 28
 CandidateContest	NC Senate District 29	NC STATE SENATE DISTRICT 29
+CandidateContest	NC Senate District 29	NC Senate District 29
 CandidateContest	NC Senate District 30	NC STATE SENATE DISTRICT 30
 CandidateContest	NC Senate District 31	NC STATE SENATE DISTRICT 31
+CandidateContest	NC Senate District 31	NC Senate District 31
 CandidateContest	NC Senate District 32	NC STATE SENATE DISTRICT 32
 CandidateContest	NC Senate District 33	NC STATE SENATE DISTRICT 33
+CandidateContest	NC Senate District 33	NC Senate District 33
 CandidateContest	NC Senate District 34	NC STATE SENATE DISTRICT 34
 CandidateContest	NC Senate District 35	NC STATE SENATE DISTRICT 35
+CandidateContest	NC Senate District 35	NC Senate District 35
 CandidateContest	NC Senate District 36	NC STATE SENATE DISTRICT 36
 CandidateContest	NC Senate District 37	NC STATE SENATE DISTRICT 37
+CandidateContest	NC Senate District 37	NC Senate District 37
 CandidateContest	NC Senate District 38	NC STATE SENATE DISTRICT 38
 CandidateContest	NC Senate District 39	NC STATE SENATE DISTRICT 39
+CandidateContest	NC Senate District 39	NC Senate District 39
 CandidateContest	NC Senate District 40	NC STATE SENATE DISTRICT 40
 CandidateContest	NC Senate District 41	NC STATE SENATE DISTRICT 41
+CandidateContest	NC Senate District 41	NC Senate District 41
 CandidateContest	NC Senate District 42	NC STATE SENATE DISTRICT 42
 CandidateContest	NC Senate District 43	NC STATE SENATE DISTRICT 43
+CandidateContest	NC Senate District 43	NC Senate District 43
 CandidateContest	NC Senate District 44	NC STATE SENATE DISTRICT 44
 CandidateContest	NC Senate District 45	NC STATE SENATE DISTRICT 45
+CandidateContest	NC Senate District 45	NC Senate District 45
 CandidateContest	NC Senate District 46	NC STATE SENATE DISTRICT 46
 CandidateContest	NC Senate District 47	NC STATE SENATE DISTRICT 47
+CandidateContest	NC Senate District 47	NC Senate District 47
 CandidateContest	NC Senate District 48	NC STATE SENATE DISTRICT 48
 CandidateContest	NC Senate District 49	NC STATE SENATE DISTRICT 49
+CandidateContest	NC Senate District 49	NC Senate District 49
 CandidateContest	NC Senate District 50	NC STATE SENATE DISTRICT 50
 CandidateContest	US House NC District 1	US HOUSE OF REPRESENTATIVES DISTRICT 1
+CandidateContest	US House NC District 1	US House NC District 1
 CandidateContest	US House NC District 1	US HOUSE OF REPRESENTATIVES DISTRICT 01
 CandidateContest	US House NC District 2	US HOUSE OF REPRESENTATIVES DISTRICT 2
+CandidateContest	US House NC District 2	US House NC District 2
 CandidateContest	US House NC District 2	US HOUSE OF REPRESENTATIVES DISTRICT 02
 CandidateContest	US House NC District 3	US HOUSE OF REPRESENTATIVES DISTRICT 3
+CandidateContest	US House NC District 3	US House NC District 3
 CandidateContest	US House NC District 3	US HOUSE OF REPRESENTATIVES DISTRICT 03
 CandidateContest	US House NC District 4	US HOUSE OF REPRESENTATIVES DISTRICT 4
+CandidateContest	US House NC District 4	US House NC District 4
 CandidateContest	US House NC District 4	US HOUSE OF REPRESENTATIVES DISTRICT 04
 CandidateContest	US House NC District 5	US HOUSE OF REPRESENTATIVES DISTRICT 5
+CandidateContest	US House NC District 5	US House NC District 5
 CandidateContest	US House NC District 5	US HOUSE OF REPRESENTATIVES DISTRICT 05
 CandidateContest	US House NC District 6	US HOUSE OF REPRESENTATIVES DISTRICT 6
+CandidateContest	US House NC District 6	US House NC District 6
 CandidateContest	US House NC District 6	US HOUSE OF REPRESENTATIVES DISTRICT 06
 CandidateContest	US House NC District 7	US HOUSE OF REPRESENTATIVES DISTRICT 7
+CandidateContest	US House NC District 7	US House NC District 7
 CandidateContest	US House NC District 7	US HOUSE OF REPRESENTATIVES DISTRICT 07
 CandidateContest	US House NC District 8	US HOUSE OF REPRESENTATIVES DISTRICT 8
+CandidateContest	US House NC District 8	US House NC District 8
 CandidateContest	US House NC District 8	US HOUSE OF REPRESENTATIVES DISTRICT 08
 CandidateContest	US House NC District 9	US HOUSE OF REPRESENTATIVES DISTRICT 9
+CandidateContest	US House NC District 9	US House NC District 9
 CandidateContest	US House NC District 9	US HOUSE OF REPRESENTATIVES DISTRICT 09
 CandidateContest	US House NC District 10	US HOUSE OF REPRESENTATIVES DISTRICT 10
+CandidateContest	US House NC District 10	US House NC District 10
 CandidateContest	US House NC District 11	US HOUSE OF REPRESENTATIVES DISTRICT 11
 CandidateContest	US House NC District 12	US HOUSE OF REPRESENTATIVES DISTRICT 12
+CandidateContest	US House NC District 12	US House NC District 12
 CandidateContest	US House NC District 13	US HOUSE OF REPRESENTATIVES DISTRICT 13
 CandidateContest	US President (NC)	US PRESIDENT
+CandidateContest	US President (NC)	US President (NC)
 CandidateContest	NC Governor	NC GOVERNOR
 CandidateContest	US Senate NC	US SENATE
+CandidateContest	US Senate NC	US Senate NC
 CandidateContest	NC Attorney General	NC ATTORNEY GENERAL
 CandidateContest	NC Lieutenant Governor	NC LIEUTENANT GOVERNOR
+CandidateContest	NC Lieutenant Governor	NC Lieutenant Governor
 CandidateContest	NC Treasurer	NC TREASURER
 CandidateContest	NC Superintendent of Public Instruction	NC SUPERINTENDENT OF PUBLIC INSTRUCTION
+CandidateContest	NC Superintendent of Public Instruction	NC Superintendent of Public Instruction
 CandidateContest	NC Commissioner of Insurance	NC COMMISSIONER OF INSURANCE
 CandidateContest	NC Commissioner of Agriculture	NC COMMISSIONER OF AGRICULTURE
+CandidateContest	NC Commissioner of Agriculture	NC Commissioner of Agriculture
 CandidateContest	NC Commissioner of Labor	NC COMMISSIONER OF LABOR
 CandidateContest	NC Auditor	NC AUDITOR
+CandidateContest	NC Auditor	NC Auditor
 CandidateContest	NC Secretary of State	NC SECRETARY OF STATE
 Election	2020 General	2020 General
 Election	2020 Primary	2020 Primary
@@ -14731,3 +14834,202 @@ Candidate	Cheri Beasley	Cheri Beasley
 Candidate	Theresa (Terri) Everett (Write-In)	Theresa (Terri) Everett (Write-In)
 Candidate	Jade Simmons (Write-In)	Jade Simmons (Write-In)
 Candidate	Darren Joiner (Write-In)	Darren Joiner (Write-In)
+CandidateContest	US House NC District 13	US House NC District 13
+CandidateContest	US House NC District 11	US House NC District 11
+CandidateContest	NC Treasurer	NC Treasurer
+CandidateContest	NC Senate District 8	NC Senate District 8
+CandidateContest	NC Senate District 6	NC Senate District 6
+CandidateContest	NC Senate District 50	NC Senate District 50
+CandidateContest	NC Senate District 48	NC Senate District 48
+CandidateContest	NC Senate District 46	NC Senate District 46
+CandidateContest	NC Senate District 44	NC Senate District 44
+CandidateContest	NC Senate District 42	NC Senate District 42
+CandidateContest	NC Senate District 40	NC Senate District 40
+CandidateContest	NC Senate District 4	NC Senate District 4
+CandidateContest	NC Senate District 38	NC Senate District 38
+CandidateContest	NC Senate District 36	NC Senate District 36
+CandidateContest	NC Senate District 34	NC Senate District 34
+CandidateContest	NC Senate District 32	NC Senate District 32
+CandidateContest	NC Senate District 30	NC Senate District 30
+CandidateContest	NC Senate District 28	NC Senate District 28
+CandidateContest	NC Senate District 26	NC Senate District 26
+CandidateContest	NC Senate District 24	NC Senate District 24
+CandidateContest	NC Senate District 22	NC Senate District 22
+CandidateContest	NC Senate District 20	NC Senate District 20
+CandidateContest	NC Senate District 2	NC Senate District 2
+CandidateContest	NC Senate District 18	NC Senate District 18
+CandidateContest	NC Senate District 16	NC Senate District 16
+CandidateContest	NC Senate District 14	NC Senate District 14
+CandidateContest	NC Senate District 12	NC Senate District 12
+CandidateContest	NC Senate District 10	NC Senate District 10
+CandidateContest	NC Secretary of State	NC Secretary of State
+CandidateContest	NC House District 98	NC House District 98
+CandidateContest	NC House District 96	NC House District 96
+CandidateContest	NC House District 94	NC House District 94
+CandidateContest	NC House District 92	NC House District 92
+CandidateContest	NC House District 90	NC House District 90
+CandidateContest	NC House District 88	NC House District 88
+CandidateContest	NC House District 86	NC House District 86
+CandidateContest	NC House District 84	NC House District 84
+CandidateContest	NC House District 82	NC House District 82
+CandidateContest	NC House District 80	NC House District 80
+CandidateContest	NC House District 8	NC House District 8
+CandidateContest	NC House District 78	NC House District 78
+CandidateContest	NC House District 76	NC House District 76
+CandidateContest	NC House District 74	NC House District 74
+CandidateContest	NC House District 72	NC House District 72
+CandidateContest	NC House District 70	NC House District 70
+CandidateContest	NC House District 68	NC House District 68
+CandidateContest	NC House District 66	NC House District 66
+CandidateContest	NC House District 64	NC House District 64
+CandidateContest	NC House District 62	NC House District 62
+CandidateContest	NC House District 60	NC House District 60
+CandidateContest	NC House District 6	NC House District 6
+CandidateContest	NC House District 58	NC House District 58
+CandidateContest	NC House District 56	NC House District 56
+CandidateContest	NC House District 54	NC House District 54
+CandidateContest	NC House District 52	NC House District 52
+CandidateContest	NC House District 50	NC House District 50
+CandidateContest	NC House District 48	NC House District 48
+CandidateContest	NC House District 46	NC House District 46
+CandidateContest	NC House District 44	NC House District 44
+CandidateContest	NC House District 42	NC House District 42
+CandidateContest	NC House District 40	NC House District 40
+CandidateContest	NC House District 4	NC House District 4
+CandidateContest	NC House District 38	NC House District 38
+CandidateContest	NC House District 36	NC House District 36
+CandidateContest	NC House District 34	NC House District 34
+CandidateContest	NC House District 32	NC House District 32
+CandidateContest	NC House District 30	NC House District 30
+CandidateContest	NC House District 28	NC House District 28
+CandidateContest	NC House District 26	NC House District 26
+CandidateContest	NC House District 24	NC House District 24
+CandidateContest	NC House District 22	NC House District 22
+CandidateContest	NC House District 20	NC House District 20
+CandidateContest	NC House District 2	NC House District 2
+CandidateContest	NC House District 18	NC House District 18
+CandidateContest	NC House District 16	NC House District 16
+CandidateContest	NC House District 14	NC House District 14
+CandidateContest	NC House District 120	NC House District 120
+CandidateContest	NC House District 12	NC House District 12
+CandidateContest	NC House District 118	NC House District 118
+CandidateContest	NC House District 116	NC House District 116
+CandidateContest	NC House District 114	NC House District 114
+CandidateContest	NC House District 112	NC House District 112
+CandidateContest	NC House District 110	NC House District 110
+CandidateContest	NC House District 108	NC House District 108
+CandidateContest	NC House District 106	NC House District 106
+CandidateContest	NC House District 104	NC House District 104
+CandidateContest	NC House District 102	NC House District 102
+CandidateContest	NC House District 100	NC House District 100
+CandidateContest	NC House District 10	NC House District 10
+CandidateContest	NC Governor	NC Governor
+CandidateContest	NC Commissioner of Labor	NC Commissioner of Labor
+CandidateContest	NC Commissioner of Insurance	NC Commissioner of Insurance
+CandidateContest	NC Attorney General	NC Attorney General
+Party	none or unknown	none or unknown
+Party	Republican Party	Republican Party
+Party	Libertarian Party	Libertarian Party
+Party	Green Party	Green Party
+Party	Democratic Party	Democratic Party
+Party	Constitution Party	Constitution Party
+ReportingUnit	North Carolina;Yancey County	North Carolina;Yancey County
+ReportingUnit	North Carolina;Yadkin County	North Carolina;Yadkin County
+ReportingUnit	North Carolina;Wilson County	North Carolina;Wilson County
+ReportingUnit	North Carolina;Wilkes County	North Carolina;Wilkes County
+ReportingUnit	North Carolina;Wayne County	North Carolina;Wayne County
+ReportingUnit	North Carolina;Watauga County	North Carolina;Watauga County
+ReportingUnit	North Carolina;Washington County	North Carolina;Washington County
+ReportingUnit	North Carolina;Warren County	North Carolina;Warren County
+ReportingUnit	North Carolina;Wake County	North Carolina;Wake County
+ReportingUnit	North Carolina;Vance County	North Carolina;Vance County
+ReportingUnit	North Carolina;Union County	North Carolina;Union County
+ReportingUnit	North Carolina;Tyrrell County	North Carolina;Tyrrell County
+ReportingUnit	North Carolina;Transylvania County	North Carolina;Transylvania County
+ReportingUnit	North Carolina;Swain County	North Carolina;Swain County
+ReportingUnit	North Carolina;Surry County	North Carolina;Surry County
+ReportingUnit	North Carolina;Stokes County	North Carolina;Stokes County
+ReportingUnit	North Carolina;Stanly County	North Carolina;Stanly County
+ReportingUnit	North Carolina;Scotland County	North Carolina;Scotland County
+ReportingUnit	North Carolina;Sampson County	North Carolina;Sampson County
+ReportingUnit	North Carolina;Rutherford County	North Carolina;Rutherford County
+ReportingUnit	North Carolina;Rowan County	North Carolina;Rowan County
+ReportingUnit	North Carolina;Rockingham County	North Carolina;Rockingham County
+ReportingUnit	North Carolina;Robeson County	North Carolina;Robeson County
+ReportingUnit	North Carolina;Richmond County	North Carolina;Richmond County
+ReportingUnit	North Carolina;Randolph County	North Carolina;Randolph County
+ReportingUnit	North Carolina;Polk County	North Carolina;Polk County
+ReportingUnit	North Carolina;Pitt County	North Carolina;Pitt County
+ReportingUnit	North Carolina;Person County	North Carolina;Person County
+ReportingUnit	North Carolina;Perquimans County	North Carolina;Perquimans County
+ReportingUnit	North Carolina;Pender County	North Carolina;Pender County
+ReportingUnit	North Carolina;Pasquotank County	North Carolina;Pasquotank County
+ReportingUnit	North Carolina;Pamlico County	North Carolina;Pamlico County
+ReportingUnit	North Carolina;Orange County	North Carolina;Orange County
+ReportingUnit	North Carolina;Onslow County	North Carolina;Onslow County
+ReportingUnit	North Carolina;Northampton County	North Carolina;Northampton County
+ReportingUnit	North Carolina;New Hanover County	North Carolina;New Hanover County
+ReportingUnit	North Carolina;Nash County	North Carolina;Nash County
+ReportingUnit	North Carolina;Moore County	North Carolina;Moore County
+ReportingUnit	North Carolina;Montgomery County	North Carolina;Montgomery County
+ReportingUnit	North Carolina;Mitchell County	North Carolina;Mitchell County
+ReportingUnit	North Carolina;Mecklenburg County	North Carolina;Mecklenburg County
+ReportingUnit	North Carolina;Mcdowell County	North Carolina;Mcdowell County
+ReportingUnit	North Carolina;Martin County	North Carolina;Martin County
+ReportingUnit	North Carolina;Madison County	North Carolina;Madison County
+ReportingUnit	North Carolina;Macon County	North Carolina;Macon County
+ReportingUnit	North Carolina;Lincoln County	North Carolina;Lincoln County
+ReportingUnit	North Carolina;Lenoir County	North Carolina;Lenoir County
+ReportingUnit	North Carolina;Lee County	North Carolina;Lee County
+ReportingUnit	North Carolina;Jones County	North Carolina;Jones County
+ReportingUnit	North Carolina;Johnston County	North Carolina;Johnston County
+ReportingUnit	North Carolina;Jackson County	North Carolina;Jackson County
+ReportingUnit	North Carolina;Iredell County	North Carolina;Iredell County
+ReportingUnit	North Carolina;Hyde County	North Carolina;Hyde County
+ReportingUnit	North Carolina;Hoke County	North Carolina;Hoke County
+ReportingUnit	North Carolina;Hertford County	North Carolina;Hertford County
+ReportingUnit	North Carolina;Henderson County	North Carolina;Henderson County
+ReportingUnit	North Carolina;Haywood County	North Carolina;Haywood County
+ReportingUnit	North Carolina;Harnett County	North Carolina;Harnett County
+ReportingUnit	North Carolina;Halifax County	North Carolina;Halifax County
+ReportingUnit	North Carolina;Guilford County	North Carolina;Guilford County
+ReportingUnit	North Carolina;Greene County	North Carolina;Greene County
+ReportingUnit	North Carolina;Granville County	North Carolina;Granville County
+ReportingUnit	North Carolina;Graham County	North Carolina;Graham County
+ReportingUnit	North Carolina;Gates County	North Carolina;Gates County
+ReportingUnit	North Carolina;Gaston County	North Carolina;Gaston County
+ReportingUnit	North Carolina;Franklin County	North Carolina;Franklin County
+ReportingUnit	North Carolina;Forsyth County	North Carolina;Forsyth County
+ReportingUnit	North Carolina;Edgecombe County	North Carolina;Edgecombe County
+ReportingUnit	North Carolina;Durham County	North Carolina;Durham County
+ReportingUnit	North Carolina;Duplin County	North Carolina;Duplin County
+ReportingUnit	North Carolina;Davie County	North Carolina;Davie County
+ReportingUnit	North Carolina;Davidson County	North Carolina;Davidson County
+ReportingUnit	North Carolina;Dare County	North Carolina;Dare County
+ReportingUnit	North Carolina;Currituck County	North Carolina;Currituck County
+ReportingUnit	North Carolina;Cumberland County	North Carolina;Cumberland County
+ReportingUnit	North Carolina;Craven County	North Carolina;Craven County
+ReportingUnit	North Carolina;Columbus County	North Carolina;Columbus County
+ReportingUnit	North Carolina;Cleveland County	North Carolina;Cleveland County
+ReportingUnit	North Carolina;Clay County	North Carolina;Clay County
+ReportingUnit	North Carolina;Chowan County	North Carolina;Chowan County
+ReportingUnit	North Carolina;Cherokee County	North Carolina;Cherokee County
+ReportingUnit	North Carolina;Chatham County	North Carolina;Chatham County
+ReportingUnit	North Carolina;Catawba County	North Carolina;Catawba County
+ReportingUnit	North Carolina;Caswell County	North Carolina;Caswell County
+ReportingUnit	North Carolina;Carteret County	North Carolina;Carteret County
+ReportingUnit	North Carolina;Camden County	North Carolina;Camden County
+ReportingUnit	North Carolina;Caldwell County	North Carolina;Caldwell County
+ReportingUnit	North Carolina;Cabarrus County	North Carolina;Cabarrus County
+ReportingUnit	North Carolina;Burke County	North Carolina;Burke County
+ReportingUnit	North Carolina;Buncombe County	North Carolina;Buncombe County
+ReportingUnit	North Carolina;Brunswick County	North Carolina;Brunswick County
+ReportingUnit	North Carolina;Bladen County	North Carolina;Bladen County
+ReportingUnit	North Carolina;Bertie County	North Carolina;Bertie County
+ReportingUnit	North Carolina;Beaufort County	North Carolina;Beaufort County
+ReportingUnit	North Carolina;Avery County	North Carolina;Avery County
+ReportingUnit	North Carolina;Ashe County	North Carolina;Ashe County
+ReportingUnit	North Carolina;Anson County	North Carolina;Anson County
+ReportingUnit	North Carolina;Alleghany County	North Carolina;Alleghany County
+ReportingUnit	North Carolina;Alexander County	North Carolina;Alexander County
+ReportingUnit	North Carolina;Alamance County	North Carolina;Alamance County

--- a/src/jurisdictions/North-Carolina/dictionary.txt
+++ b/src/jurisdictions/North-Carolina/dictionary.txt
@@ -14933,6 +14933,7 @@ Party	Libertarian Party	Libertarian Party
 Party	Green Party	Green Party
 Party	Democratic Party	Democratic Party
 Party	Constitution Party	Constitution Party
+Party	Unaffiliated	Unaffiliated
 ReportingUnit	North Carolina;Yancey County	North Carolina;Yancey County
 ReportingUnit	North Carolina;Yadkin County	North Carolina;Yadkin County
 ReportingUnit	North Carolina;Wilson County	North Carolina;Wilson County

--- a/src/mungers/000_template.munger
+++ b/src/mungers/000_template.munger
@@ -1,9 +1,9 @@
 # Format parameters section (required) #
 [format]
-#### REQUIRED! File type must be one of: valid_nist_xml,excel,json-nested,xml,flat_text
+#### REQUIRED! File type must be one of: nist_v2_xml,excel,json-nested,xml,flat_text
 file_type=
 
-## Required for all file types except valid_nist_xml):
+## Required for all file types except nist_v2_xml):
 #### Counts are found in one way of: by_field_names,by_column_numbers
 count_locations=
 #### Munge string locations must be sublist of: in_field_values,in_count_headers,constant_over_sheet,constant_over_file ##

--- a/src/mungers/nh_xls_by_county_multi.munger
+++ b/src/mungers/nh_xls_by_county_multi.munger
@@ -1,9 +1,9 @@
 # Format parameters section (required) #
 [format]
-#### REQUIRED! File type must be one of: valid_nist_xml,excel,json-nested,xml,flat_text
+#### REQUIRED! File type must be one of: nist_v2_xml,excel,json-nested,xml,flat_text
 file_type=excel
 
-## Required for all file types except valid_nist_xml):
+## Required for all file types except nist_v2_xml):
 #### Counts are found in one way of: by_field_names,by_column_numbers
 count_locations=by_column_numbers
 #### Munge string locations must be sublist of: in_field_values,in_count_headers,constant_over_sheet,constant_over_file ##

--- a/src/mungers/nist_v2_xml.munger
+++ b/src/mungers/nist_v2_xml.munger
@@ -1,5 +1,5 @@
 # Format parameters section (required) #
 [format]
-file_type=valid_nist_xml
+file_type=nist_v2_xml
 
 


### PR DESCRIPTION
- Allows export in NIST V2 format, including option to export by county (or major subdivision)
- Creates method to rollup an arbitrary results dataframe to county (or other major subdivision) (Analyzer.rollup())
- Adds function to find list of datafiles by session, not just by cursor